### PR TITLE
added battery level indicator sequence when the movuino is powered on…

### DIFF
--- a/03_Firmware/SensitivePen_ESP32/README.md
+++ b/03_Firmware/SensitivePen_ESP32/README.md
@@ -34,7 +34,7 @@ newDat,newDat,newDat,newDat,...
 
 - Wire
 - I2Cdev
-- MPU9250
+- [MPU9250 BolderFlight **v1.0**](https://github.com/bolderflight/mpu9250)
 - FS
 - Adafruit_NeoPixel 
-- Yabl
+- [Yabl](https://github.com/yergin/yabl)


### PR DESCRIPTION
Added battery level indicator sequence when the movuino is powered on; For the first 5 seconds, the LED will indicate the battery level. >50% = Green; >25% = Yellow; <25% = Red